### PR TITLE
Fixed Running Pod Count based on phase

### DIFF
--- a/dashboards/k8s-views-global.json
+++ b/dashboards/k8s-views-global.json
@@ -435,8 +435,18 @@
           },
           "expr": "sum(kube_pod_container_status_running)",
           "interval": "",
-          "legendFormat": "Running Pods",
+          "legendFormat": "Running Containers",
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kube_pod_status_phase{phase='Running'})",
+          "interval": "",
+          "legendFormat": "Running Pods",
+          "refId": "O"
         },
         {
           "datasource": {
@@ -871,7 +881,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(kube_pod_info)",
+          "expr": "sum(kube_pod_status_phase{phase='Running'})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
Fixed 2 graphs showing incorrect numbers for pods.

# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

- Running pod counts are incorrect.  Changed to be based on phase="running"

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

- none

### :speech_balloon: Additional information?

- The original values for me were reporting 88 running pods, but K8s LENS reported 83 pods.   When I switched to phase="running" I got a matching 83 pods.   Possible what you were using also picks up "jobs" as I had 5 completed jobs which gives the "88".
- I was unable to test this version directly as I have other customizations for my K3s / containerd but wanted to pass this correction back to you. 
