### PR TITLE
Update variable query string for nodes dashboard

### DIFF
--- a/dashboards/k8s-views-nodes.json
+++ b/dashboards/k8s-views-nodes.json
@@ -3649,14 +3649,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(node_uname_info{job=\"$job\"}, nodename)",
+        "definition": "label_values(kube_node_info, node)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(node_uname_info{job=\"$job\"}, nodename)",
+          "query": "label_values(kube_node_info, node)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -3675,14 +3675,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(node_uname_info{nodename=\"$node\"}, instance)",
+        "definition": "label_values(node_uname_info{nodename=~\"(?i:($node))\"}, instance)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(node_uname_info{nodename=\"$node\"}, instance)",
+          "query": "label_values(node_uname_info{nodename=~\"(?i:($node))\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -3701,6 +3701,6 @@
   "timezone": "",
   "title": "Kubernetes / Views / Nodes",
   "uid": "k8s_views_nodes",
-  "version": 8,
+  "version": 9,
   "weekStart": ""
 }


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

- Updated node variable to source node name information from `kube_node_info` instead of `node_uname_info`. On AKS deployments `node_uname_info` returns node name with capitalised last character (ie, `aks-a12bcdef-0123456789-vmss00006H`), but at the same time node name provided by `kube_node_info` is lower cased (ie `aks-a12bcdef-0123456789-vmss00006h`). As result some dashboard panels do not visualise information correctly.
- This PR partially addresses #3 