### PR TITLE
Update k8s-views-global.json

### DIFF
--- a/dashboards/k8s-views-global.json
+++ b/dashboards/k8s-views-global.json
@@ -1494,7 +1494,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(container_memory_working_set_bytes{image!=\"\"}) by (node)",
+          "expr": "sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) by (instance)",
           "interval": "$resolution",
           "legendFormat": "{{ node}}",
           "range": true,


### PR DESCRIPTION
Updated to show "real" memory usage by instance (node).  These values now add up the Real Global RAM Usage amount.

# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix 

### :dart: What has been changed and why do we need it?

- Memory usage by node (instance) updated to match Real Global RAM usage amount.

![image](https://user-images.githubusercontent.com/16230914/180800165-5f5511b2-b6e8-4882-9018-a92be370ed3e.png)

Now Matches:
![image](https://user-images.githubusercontent.com/16230914/180800294-d62a03bd-0c96-4346-8729-5046d5133a15.png)
