### PR TITLE
[fix]apiserver request latancy should use apiserver_request_duration_…

### DIFF
--- a/dashboards/k8s-system-api-server.json
+++ b/dashboards/k8s-system-api-server.json
@@ -559,7 +559,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "sum(rate(rest_client_request_duration_seconds_bucket{job=\"apiserver\"}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"}[$__rate_interval])) by (instance)",
           "interval": "$resolution",
           "legendFormat": "{{ instance }}",
           "refId": "A"
@@ -650,7 +650,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "sum(rate(rest_client_request_duration_seconds_bucket{job=\"apiserver\"}[$__rate_interval])) by (verb)",
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"}[$__rate_interval])) by (verb)",
           "interval": "$resolution",
           "legendFormat": "{{ verb }}",
           "refId": "A"


### PR DESCRIPTION
…seconds_bucket

# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix 

### :dart: What has been changed and why do we need it?

- apiserver request latancy metric should be apiserver_request_duration_seconds_bucket other than rest_client_request_duration_seconds_bucket

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

- ...

### :speech_balloon: Additional information?

- ...
