### PR TITLE
Remove default kustomization namespace

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -5,7 +5,6 @@ generatorOptions:
     grafana_dashboard: "true"
 commonAnnotations:
   grafana_folder: "Kubernetes"
-namespace: monitoring
 
 # Generate a ConfigMap for each dashboard
 configMapGenerator:


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

feat

### :dart: What has been changed and why do we need it?

By removing the default value, one can copy the argocd.yaml file into one's own git repository, refer directly to this repo on Github (thus benefiting from updates), /and/ pick a custom namespace to target.

If the kustomization.yaml file contains a target namespace already, there seems to be [no straightforward way](https://github.com/kubernetes-sigs/kustomize/issues/880) to override this from ArgoCD.