### PR TITLE
add link from node dashboard to pods

### DIFF
--- a/dashboards/k8s-views-nodes.json
+++ b/dashboards/k8s-views-nodes.json
@@ -309,6 +309,11 @@
             "displayMode": "auto",
             "inspect": false
           },
+          "links": [{
+            "targetBlank": true,
+            "title": "Pod details",
+            "url": "/d/k8s_views_pods/kubernetes-views-pods?${datasource:queryparam}&var-namespace=${__data.fields.namespace}&var-pod=${__data.fields.pod}&${resolution:queryparam}&${__url_time_range}"
+          }],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- feat

### :dart: What has been changed and why do we need it?

- added drill down link from Node dashboard to Pod dashboard. Clicking on pod in list of pods now brings you directly to pod dashboard for this pod
![CleanShot 2022-09-26 at 19 42 42@2x](https://user-images.githubusercontent.com/7897050/192268155-68e0268c-44fe-4a1a-ac7e-858f60b8362a.png)


