### PR TITLE
set percentage 2 decimals long for memory usage

### DIFF
--- a/dashboards/k8s-views-global.json
+++ b/dashboards/k8s-views-global.json
@@ -192,6 +192,7 @@
           "color": {
             "mode": "continuous-GrYlRd"
           },
+          "decimals": 2,
           "mappings": [],
           "max": 1,
           "min": 0,


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix 

### :dart: What has been changed and why do we need it?

Percentage for cluster memory utilization didn't have a decimal limit while other percentage on this dashboard are set to 2.
I doubt that this was intented so here's a fix.

![dashboardfix](https://user-images.githubusercontent.com/10053686/195557223-e1d30d94-1274-414b-98bc-779994ccd91f.png)



## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

- No open issues

### :speech_balloon: Additional information?

- Let me know if something need to be added to merge this PR
