### PR TITLE
Return correct instance when node is changed

### DIFF
--- a/dashboards/k8s-views-nodes.json
+++ b/dashboards/k8s-views-nodes.json
@@ -3754,14 +3754,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(node_uname_info{job=\"$job\"}, instance)",
+        "definition": "label_values(node_uname_info{nodename=\"$node\",job=\"$job\"}, instance)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(node_uname_info{job=\"$job\"}, instance)",
+          "query": "label_values(node_uname_info{nodename=\"$node\",job=\"$job\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

- In the k8s-view-nodes dashboard, without this change, some of the panels didn't show correct data as instances never updated when a node is changed. I added `nodename` to select the proper instance.

This is broken after this PR has been merged: https://github.com/dotdc/grafana-dashboards-kubernetes/pull/39

I'm using Rancher K3s Kubernetes distribution. but I see that **OKE** does not have the same values for `node` in `kube_node_info` and `node_uname_info` expressions.

Maybe we should try to cover both cases @fcecagno?

Thanks!
