### PR TITLE
Fix PromQL epxression for coredns average packet size

### DIFF
--- a/dashboards/k8s-system-coredns.json
+++ b/dashboards/k8s-system-coredns.json
@@ -507,7 +507,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "avg(rate(coredns_dns_request_size_bytes_sum{instance=~\"$instance\",proto=\"$protocol\"}[$__rate_interval])) by (proto)",
+          "expr": "sum(rate(coredns_dns_request_size_bytes_sum{instance=~\"$instance\",proto=\"$protocol\"}[$__rate_interval])) by (proto) / sum(rate(coredns_dns_request_size_bytes_count{instance=~\"$instance\",proto=\"$protocol\"}[$__rate_interval])) by (proto)",
           "interval": "$resolution",
           "legendFormat": "average $protocol packet size",
           "refId": "A"
@@ -1553,6 +1553,6 @@
   "timezone": "",
   "title": "Kubernetes / System / CoreDNS",
   "uid": "k8s_system_coredns",
-  "version": 11,
+  "version": 12,
   "weekStart": ""
 }


### PR DESCRIPTION
The method for taking the average of a histogram metric is documented here:
https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations

# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

Fix the PromQL expression for CoreDNS request average packet size. The value being shown was a meaningless value: the average across all CoreDNS servers of the sum of all request packet sizes in each server over `$__rate_interval`. This is not the average size of packets received by CoreDNS servers over `$__rate_interval`, which I imagine is what was intended.

The old query, explained another way:

- `coredns_dns_request_size_bytes_sum` is the sum of sizes of all request packets ever received.
- `rate(coredns_dns_request_size_bytes_sum[$__rate_interval])`, by itself, is the per-second rate of increase of the sum of sizes of request packets received during `$__rate_interval`. This isn't a meaningful value. This query returns a series containing this value for each CoreDNS server deployed.
- `avg(rate(coredns_dns_request_size_bytes_sum[$__rate_interval]))` takes the average of this value across all series returned -- in other words, to calculate average, it's dividing by the number of CoreDNS servers, _not_ the number of packets. An operation that doesn't make sense on top of a value that already doesn't make sense.

The new query:

- `coredns_dns_request_size_bytes_count` is the other major component of this histogram. (Histograms in general have a `_count`, a `_sum`, and some number of `_bucket`s.) This metric is the number of observations -- in other words, the number of packets whose sizes were recorded.
- We use `sum` to add up the summed packet sizes and packet counts across all CoreDNS servers.
- Divide the summed packet sizes by the number of packets. (That's the average, alright!)
- The `rate` function cancels out in this division -- you get the same value if you use the `increase` function in place of `rate`. I personally think `increase` is almost always easier to understand than `rate`, but I stuck with `rate` here because it's what [the Prometheus docs](https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations) use.