### PR TITLE
count nodes by kube_node_info, instead of node-exporter jobs

### DIFF
--- a/dashboards/k8s-views-global.json
+++ b/dashboards/k8s-views-global.json
@@ -329,7 +329,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "count(up{job=\"node-exporter\"})",
+          "expr": "count(count by (node) (kube_node_info))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -570,7 +570,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "count(up{job=\"node-exporter\"})",
+          "expr": "count(count by (node) (kube_node_info))",
           "hide": false,
           "interval": "",
           "legendFormat": "Nodes",


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix
### :dart: What has been changed and why do we need it?

- The metric `up{job="node-exporter"}` does not exist when using Grafana Agent. Counting `kube_node_info` should be agnostic and more reliable.

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

- Fixes #46

### :speech_balloon: Additional information?

- N/A
