### PR TITLE
fix(k8s-views-global): correctly escape quote

### DIFF
--- a/dashboards/k8s-views-global.json
+++ b/dashboards/k8s-views-global.json
@@ -449,7 +449,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(kube_pod_status_phase{phase='Running'})",
+          "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
           "interval": "",
           "legendFormat": "Running Pods",
           "refId": "O"
@@ -887,7 +887,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(kube_pod_status_phase{phase='Running'})",
+          "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

- there's a bug (which at least fires up with my setup (VictoriaMetrics), that a label selector is written with a single quote which returns no result.

concretely: 

```
sum(kube_pod_status_phase{phase='Running'}) # doesn't work, unescaped single quote
sum(kube_pod_status_phase{phase=\"Running\"}) # does work, with escaped quotes
```