### PR TITLE
Make trivy operator dashboard colors more consistent

### DIFF
--- a/dashboards/k8s-addons-trivy-operator.json
+++ b/dashboards/k8s-addons-trivy-operator.json
@@ -107,7 +107,7 @@
                 "value": null
               },
               {
-                "color": "dark-red",
+                "color": "red",
                 "value": 1
               }
             ]
@@ -175,7 +175,7 @@
                 "value": null
               },
               {
-                "color": "red",
+                "color": "orange",
                 "value": 1
               }
             ]
@@ -243,7 +243,7 @@
                 "value": null
               },
               {
-                "color": "orange",
+                "color": "yellow",
                 "value": 1
               }
             ]
@@ -311,7 +311,7 @@
                 "value": null
               },
               {
-                "color": "yellow",
+                "color": "blue",
                 "value": 1
               }
             ]
@@ -659,7 +659,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "dark-red",
+                  "fixedColor": "red",
                   "mode": "fixed"
                 }
               }
@@ -674,7 +674,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "red",
+                  "fixedColor": "orange",
                   "mode": "fixed"
                 }
               }
@@ -689,7 +689,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "orange",
+                  "fixedColor": "yellow",
                   "mode": "fixed"
                 }
               }
@@ -704,7 +704,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "yellow",
+                  "fixedColor": "blue",
                   "mode": "fixed"
                 }
               }
@@ -802,7 +802,7 @@
                 "value": null
               },
               {
-                "color": "red",
+                "color": "orange",
                 "value": 80
               }
             ]
@@ -821,19 +821,19 @@
                   {
                     "options": {
                       "Critical": {
-                        "color": "dark-red",
+                        "color": "red",
                         "index": 0
                       },
                       "High": {
-                        "color": "red",
+                        "color": "orange",
                         "index": 1
                       },
                       "Low": {
-                        "color": "yellow",
+                        "color": "blue",
                         "index": 3
                       },
                       "Medium": {
-                        "color": "orange",
+                        "color": "yellow",
                         "index": 2
                       },
                       "Unknown": {
@@ -1031,19 +1031,19 @@
                   {
                     "options": {
                       "Critical": {
-                        "color": "dark-red",
+                        "color": "red",
                         "index": 0
                       },
                       "High": {
-                        "color": "red",
+                        "color": "orange",
                         "index": 1
                       },
                       "Low": {
-                        "color": "yellow",
+                        "color": "blue",
                         "index": 3
                       },
                       "Medium": {
-                        "color": "orange",
+                        "color": "yellow",
                         "index": 2
                       },
                       "Unknown": {
@@ -1251,7 +1251,7 @@
                 "value": null
               },
               {
-                "color": "dark-red",
+                "color": "red",
                 "value": 1
               }
             ]
@@ -1319,7 +1319,7 @@
                 "value": null
               },
               {
-                "color": "red",
+                "color": "orange",
                 "value": 1
               }
             ]
@@ -1387,7 +1387,7 @@
                 "value": null
               },
               {
-                "color": "orange",
+                "color": "yellow",
                 "value": 1
               }
             ]
@@ -1455,7 +1455,7 @@
                 "value": null
               },
               {
-                "color": "yellow",
+                "color": "blue",
                 "value": 1
               }
             ]
@@ -1735,7 +1735,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "dark-red",
+                  "fixedColor": "red",
                   "mode": "fixed"
                 }
               }
@@ -1750,7 +1750,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "red",
+                  "fixedColor": "orange",
                   "mode": "fixed"
                 }
               }
@@ -1765,7 +1765,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "orange",
+                  "fixedColor": "yellow",
                   "mode": "fixed"
                 }
               }
@@ -1780,7 +1780,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "yellow",
+                  "fixedColor": "blue",
                   "mode": "fixed"
                 }
               }
@@ -1859,7 +1859,7 @@
                 "value": null
               },
               {
-                "color": "dark-red",
+                "color": "red",
                 "value": 1
               }
             ]
@@ -1927,7 +1927,7 @@
                 "value": null
               },
               {
-                "color": "red",
+                "color": "orange",
                 "value": 1
               }
             ]
@@ -1995,7 +1995,7 @@
                 "value": null
               },
               {
-                "color": "orange",
+                "color": "yellow",
                 "value": 1
               }
             ]
@@ -2063,7 +2063,7 @@
                 "value": null
               },
               {
-                "color": "yellow",
+                "color": "blue",
                 "value": 1
               }
             ]
@@ -2343,7 +2343,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "dark-red",
+                  "fixedColor": "red",
                   "mode": "fixed"
                 }
               }
@@ -2358,7 +2358,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "red",
+                  "fixedColor": "orange",
                   "mode": "fixed"
                 }
               }
@@ -2373,7 +2373,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "orange",
+                  "fixedColor": "yellow",
                   "mode": "fixed"
                 }
               }
@@ -2388,7 +2388,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "yellow",
+                  "fixedColor": "blue",
                   "mode": "fixed"
                 }
               }

--- a/dashboards/k8s-addons-trivy-operator.json
+++ b/dashboards/k8s-addons-trivy-operator.json
@@ -107,7 +107,7 @@
                 "value": null
               },
               {
-                "color": "blue",
+                "color": "dark-red",
                 "value": 1
               }
             ]
@@ -122,7 +122,7 @@
         "x": 0,
         "y": 1
       },
-      "id": 60,
+      "id": 51,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -146,14 +146,14 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_image_vulnerabilities{severity=\"Low\", namespace=~\"$namespace\"})",
+          "expr": "sum(trivy_image_vulnerabilities{severity=\"Critical\", namespace=~\"$namespace\"})",
           "instant": true,
           "interval": "$resolution",
           "legendFormat": "__auto",
           "refId": "A"
         }
       ],
-      "title": "LOW",
+      "title": "CRITICAL",
       "type": "stat"
     },
     {
@@ -175,7 +175,7 @@
                 "value": null
               },
               {
-                "color": "yellow",
+                "color": "red",
                 "value": 1
               }
             ]
@@ -188,74 +188,6 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 1
-      },
-      "id": 49,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.3.8",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(trivy_image_vulnerabilities{severity=\"Medium\", namespace=~\"$namespace\"})",
-          "instant": true,
-          "interval": "$resolution",
-          "legendFormat": "__auto",
-          "refId": "A"
-        }
-      ],
-      "title": "MEDIUM",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 8,
         "y": 1
       },
       "id": 50,
@@ -311,7 +243,7 @@
                 "value": null
               },
               {
-                "color": "red",
+                "color": "orange",
                 "value": 1
               }
             ]
@@ -323,10 +255,10 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 12,
+        "x": 8,
         "y": 1
       },
-      "id": 51,
+      "id": 49,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -350,14 +282,82 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_image_vulnerabilities{severity=\"Critical\", namespace=~\"$namespace\"})",
+          "expr": "sum(trivy_image_vulnerabilities{severity=\"Medium\", namespace=~\"$namespace\"})",
           "instant": true,
           "interval": "$resolution",
           "legendFormat": "__auto",
           "refId": "A"
         }
       ],
-      "title": "CRITICAL",
+      "title": "MEDIUM",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 60,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(trivy_image_vulnerabilities{severity=\"Low\", namespace=~\"$namespace\"})",
+          "instant": true,
+          "interval": "$resolution",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "LOW",
       "type": "stat"
     },
     {
@@ -649,7 +649,83 @@
           },
           "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Critical"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "High"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Medium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Low"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -745,19 +821,19 @@
                   {
                     "options": {
                       "Critical": {
-                        "color": "red",
+                        "color": "dark-red",
                         "index": 0
                       },
                       "High": {
-                        "color": "orange",
+                        "color": "red",
                         "index": 1
                       },
                       "Low": {
-                        "color": "blue",
+                        "color": "yellow",
                         "index": 3
                       },
                       "Medium": {
-                        "color": "yellow",
+                        "color": "orange",
                         "index": 2
                       },
                       "Unknown": {
@@ -955,19 +1031,19 @@
                   {
                     "options": {
                       "Critical": {
-                        "color": "red",
+                        "color": "dark-red",
                         "index": 0
                       },
                       "High": {
-                        "color": "orange",
+                        "color": "red",
                         "index": 1
                       },
                       "Low": {
-                        "color": "blue",
+                        "color": "yellow",
                         "index": 3
                       },
                       "Medium": {
-                        "color": "yellow",
+                        "color": "orange",
                         "index": 2
                       },
                       "Unknown": {
@@ -1175,7 +1251,7 @@
                 "value": null
               },
               {
-                "color": "blue",
+                "color": "dark-red",
                 "value": 1
               }
             ]
@@ -1190,7 +1266,7 @@
         "x": 0,
         "y": 39
       },
-      "id": 53,
+      "id": 56,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -1214,14 +1290,14 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_resource_configaudits{severity=\"Low\", namespace=~\"$namespace\"})",
+          "expr": "sum(trivy_resource_configaudits{severity=\"Critical\", namespace=~\"$namespace\"})",
           "instant": true,
           "interval": "$resolution",
           "legendFormat": "__auto",
           "refId": "A"
         }
       ],
-      "title": "LOW",
+      "title": "CRITICAL",
       "type": "stat"
     },
     {
@@ -1243,7 +1319,7 @@
                 "value": null
               },
               {
-                "color": "yellow",
+                "color": "red",
                 "value": 1
               }
             ]
@@ -1256,74 +1332,6 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 39
-      },
-      "id": 54,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.3.8",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(trivy_resource_configaudits{severity=\"Medium\", namespace=~\"$namespace\"})",
-          "instant": true,
-          "interval": "$resolution",
-          "legendFormat": "__auto",
-          "refId": "A"
-        }
-      ],
-      "title": "MEDIUM",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 8,
         "y": 39
       },
       "id": 55,
@@ -1379,7 +1387,7 @@
                 "value": null
               },
               {
-                "color": "red",
+                "color": "orange",
                 "value": 1
               }
             ]
@@ -1391,10 +1399,10 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 12,
+        "x": 8,
         "y": 39
       },
-      "id": 56,
+      "id": 54,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -1418,14 +1426,82 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_resource_configaudits{severity=\"Critical\", namespace=~\"$namespace\"})",
+          "expr": "sum(trivy_resource_configaudits{severity=\"Medium\", namespace=~\"$namespace\"})",
           "instant": true,
           "interval": "$resolution",
           "legendFormat": "__auto",
           "refId": "A"
         }
       ],
-      "title": "CRITICAL",
+      "title": "MEDIUM",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 39
+      },
+      "id": 53,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(trivy_resource_configaudits{severity=\"Low\", namespace=~\"$namespace\"})",
+          "instant": true,
+          "interval": "$resolution",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "LOW",
       "type": "stat"
     },
     {
@@ -1649,7 +1725,68 @@
           },
           "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Critical"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "High"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Medium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Low"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -1722,7 +1859,7 @@
                 "value": null
               },
               {
-                "color": "blue",
+                "color": "dark-red",
                 "value": 1
               }
             ]
@@ -1737,7 +1874,7 @@
         "x": 0,
         "y": 52
       },
-      "id": 69,
+      "id": 72,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -1761,14 +1898,14 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_role_rbacassessments{severity=\"Low\", namespace=~\"$namespace\"})",
+          "expr": "sum(trivy_role_rbacassessments{severity=\"Critical\", namespace=~\"$namespace\"})",
           "instant": true,
           "interval": "$resolution",
           "legendFormat": "__auto",
           "refId": "A"
         }
       ],
-      "title": "LOW",
+      "title": "CRITICAL",
       "type": "stat"
     },
     {
@@ -1790,7 +1927,7 @@
                 "value": null
               },
               {
-                "color": "yellow",
+                "color": "red",
                 "value": 1
               }
             ]
@@ -1803,74 +1940,6 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 52
-      },
-      "id": 70,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.3.8",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(trivy_role_rbacassessments{severity=\"Medium\", namespace=~\"$namespace\"})",
-          "instant": true,
-          "interval": "$resolution",
-          "legendFormat": "__auto",
-          "refId": "A"
-        }
-      ],
-      "title": "MEDIUM",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 8,
         "y": 52
       },
       "id": 71,
@@ -1926,7 +1995,7 @@
                 "value": null
               },
               {
-                "color": "red",
+                "color": "orange",
                 "value": 1
               }
             ]
@@ -1938,10 +2007,10 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 12,
+        "x": 8,
         "y": 52
       },
-      "id": 72,
+      "id": 70,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -1965,14 +2034,82 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_role_rbacassessments{severity=\"Critical\", namespace=~\"$namespace\"})",
+          "expr": "sum(trivy_role_rbacassessments{severity=\"Medium\", namespace=~\"$namespace\"})",
           "instant": true,
           "interval": "$resolution",
           "legendFormat": "__auto",
           "refId": "A"
         }
       ],
-      "title": "CRITICAL",
+      "title": "MEDIUM",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 52
+      },
+      "id": 69,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(trivy_role_rbacassessments{severity=\"Low\", namespace=~\"$namespace\"})",
+          "instant": true,
+          "interval": "$resolution",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "LOW",
       "type": "stat"
     },
     {
@@ -2196,7 +2333,68 @@
           },
           "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Critical"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "High"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Medium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Low"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -2464,6 +2662,6 @@
   "timezone": "",
   "title": "Trivy Operator - Vulnerabilities",
   "uid": "security_trivy_operator",
-  "version": 7,
+  "version": 8,
   "weekStart": ""
 }


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- feat

### :dart: What has been changed and why do we need it?

- It makes colors in trivy-operator dashboard more consistent over the different panels (e.g. in timeseries critical was green)
- It also changes colors for
  - critical = dark red
  - high =red
  - medium = orange
  - low = yellow

