### PR TITLE
fix(apiserver-duration): compute average of duration

### DIFF
--- a/dashboards/k8s-system-api-server.json
+++ b/dashboards/k8s-system-api-server.json
@@ -576,7 +576,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(apiserver_request_duration_seconds_sum{job=\"apiserver\"}[$__rate_interval])) by (instance)\n/\nsum(rate(apiserver_request_duration_seconds_count{job=\"apiserver\"}[$__rate_interval])) by (instance)",
           "interval": "$resolution",
           "legendFormat": "{{ instance }}",
           "refId": "A"
@@ -670,7 +670,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"}[$__rate_interval])) by (verb)",
+          "expr": "sum(rate(apiserver_request_duration_seconds_sum{job=\"apiserver\"}[$__rate_interval])) by (verb)\n/\nsum(rate(apiserver_request_duration_seconds_count{job=\"apiserver\"}[$__rate_interval])) by (verb)",
           "interval": "$resolution",
           "legendFormat": "{{ verb }}",
           "refId": "A"


### PR DESCRIPTION
without the fix, the dashboards show the cumulative duration of all buckets, which doesn't make much sense. (we plot `sum by (instance)` of buckets, and there are ~10 buckets (`le="0.05", le="0.1", ..., le="+Inf"`). this doesn't represent the latency of the API server.
with the fix, we divide the total duration by the number of requests, which yields the average latency. note that we could also have used `_duration_seconds_bucket{le="+Inf"}` instead of `duration_seconds_sum`

# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

before:
<img width="1106" alt="image" src="https://github.com/dotdc/grafana-dashboards-kubernetes/assets/2116997/509f3c79-7689-47fb-9761-c853abf3dfad">

after:
<img width="1117" alt="image" src="https://github.com/dotdc/grafana-dashboards-kubernetes/assets/2116997/8057018e-1f19-441c-a74b-a33dbac71803">
