### PR TITLE
Update k8s-views-namespaces.json

### DIFF
--- a/dashboards/k8s-views-namespaces.json
+++ b/dashboards/k8s-views-namespaces.json
@@ -319,7 +319,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(kube_pod_container_status_running{namespace=~\"$namespace\", cluster=\"$cluster\"})",
+          "expr": "sum(kube_pod_info{namespace=~\"$namespace\", cluster=\"$cluster\"})",
           "interval": "",
           "legendFormat": "Running Pods",
           "refId": "A"


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

- Use kube_pod_info instead of kube_pod_container_status_running to show number of pods
