### PR TITLE
fix(k8s-system-coredns): add datasource for the job variable

### DIFF
--- a/dashboards/k8s-system-coredns.json
+++ b/dashboards/k8s-system-coredns.json
@@ -1602,6 +1602,10 @@
             "coredns"
           ]
         },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
         "definition": "label_values(coredns_build_info{cluster=\"$cluster\"},job)",
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

- Added datasource for the `job` variable in CoreDNS dashboard. It fixes CoreDNS dashboard if Grafana has multiple datasources

