### PR TITLE
kube_namespace_created replacement

### DIFF
--- a/dashboards/k8s-views-global.json
+++ b/dashboards/k8s-views-global.json
@@ -745,7 +745,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(kube_namespace_created{cluster=\"$cluster\"})",
+          "expr": "sum(kube_namespace_status_phase{cluster=\"$cluster\",phase=\"Active\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- Fix

### :dart: What has been changed and why do we need it?

- Replace deprecated kube_namespace_created metric with kube_namespace_status_phase to ensure compatibility and accurate monitoring.
