### PR TITLE
fix: pod cpu/memory usage metrics grouped by id as well

### DIFF
--- a/dashboards/k8s-views-pods.json
+++ b/dashboards/k8s-views-pods.json
@@ -1583,7 +1583,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container, id)",
           "interval": "$resolution",
           "legendFormat": "{{ container }}",
           "range": true,
@@ -1690,7 +1690,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}) by (container)",
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}) by (container, id)",
           "interval": "",
           "legendFormat": "{{ container }}",
           "range": true,
@@ -2712,6 +2712,6 @@
   "timezone": "",
   "title": "Kubernetes / Views / Pods",
   "uid": "k8s_views_pods",
-  "version": 32,
+  "version": 33,
   "weekStart": ""
 }


### PR DESCRIPTION
![metrics](https://github.com/user-attachments/assets/d29414c1-62f4-4f81-bddf-2aa1fa82ec11)
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

- Added `id` to group by for cpu/memory usage. When pod restarts the prometheus metrics for old and new pod sometimes overlap, creating spike in memory and cpu usage when 2 metrics are sumed together. Plotting then the incorectly high values which may be used to set up pod resources and limits incorrectly. See added screenshot where red and yellow lines are slightly overlapping which would cause spike without `id`.