### PR TITLE
views/pods: use wildcard for `all` option in `pod` variable

### DIFF
--- a/dashboards/k8s-views-pods.json
+++ b/dashboards/k8s-views-pods.json
@@ -2600,6 +2600,7 @@
         "useTags": false
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": false,
           "text": "",


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix 

### :dart: What has been changed and why do we need it?

`pod` variable could contain thousands of options in some environments. Selecting `all` options would mean dashboard will include all of them into the PromQL query and potentially cause issues on processing.
Switching to wildcard `.*` instead will prevent sending huge queries to database and dashboard will continue to work for any environment.

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

fixes https://github.com/dotdc/grafana-dashboards-kubernetes/issues/129