### PR TITLE
feat(k8s-views-nodes): Support FQDN nodename

### DIFF
--- a/dashboards/k8s-views-nodes.json
+++ b/dashboards/k8s-views-nodes.json
@@ -3988,14 +3988,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(node_uname_info{nodename=~\"(?i:($node))\"}, instance)",
+        "definition": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\.[a-z0-9.]+)?)\"}, instance)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(node_uname_info{nodename=~\"(?i:($node))\"}, instance)",
+          "query": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\.[a-z0-9.]+)?)\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- feat
### :dart: What has been changed and why do we need it?

- It is fairly common for the server hostname to be a FQDN (e.g. `node-01.example.com`), while the node is known to Kubernetes by it's short name (e.g. `node-01`).

  By relaxing the regex that matches the `nodename` label to determine the `instance` name, we can cover that case without the need to relabel metrics.