### PR TITLE
fix(k8s-views-nodes): double escape backslash

### DIFF
--- a/dashboards/k8s-views-nodes.json
+++ b/dashboards/k8s-views-nodes.json
@@ -3988,14 +3988,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\.[a-z0-9.]+)?)\"}, instance)",
+        "definition": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\\\.[a-z0-9.]+)?)\"}, instance)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\.[a-z0-9.]+)?)\"}, instance)",
+          "query": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\\\.[a-z0-9.]+)?)\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -4014,6 +4014,6 @@
   "timezone": "",
   "title": "Kubernetes / Views / Nodes",
   "uid": "k8s_views_nodes",
-  "version": 35,
+  "version": 36,
   "weekStart": ""
 }


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

fix

### :dart: What has been changed and why do we need it?

The query is escaped twice, and therefore the resulting backslash is considered an escape sequence for the string itself, rather than escaping the dot (.) in the regular expression.

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

#144

### :speech_balloon: Additional information?

N/A
