### PR TITLE
fix(k8s-views-namespaces): use custom all value for created_by filter

### DIFF
--- a/dashboards/k8s-views-namespaces.json
+++ b/dashboards/k8s-views-namespaces.json
@@ -2997,6 +2997,7 @@
         "type": "custom"
       },
       {
+        "allValue": ".*",
         "current": {},
         "datasource": {
           "type": "prometheus",
@@ -3029,6 +3030,6 @@
   "timezone": "",
   "title": "Kubernetes / Views / Namespaces",
   "uid": "k8s_views_ns",
-  "version": 42,
+  "version": 43,
   "weekStart": ""
 }


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

fix

### :dart: What has been changed and why do we need it?

All other filters use a custom all value as it's much more efficient than constructing a query with every single created_by value. It also prevents queries from becoming too long and rejected by Prometheus.

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

#146

### :speech_balloon: Additional information?

- ...
