### PR TITLE
Fix instance variable

### DIFF
--- a/dashboards/k8s-views-nodes.json
+++ b/dashboards/k8s-views-nodes.json
@@ -3988,14 +3988,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\\\.[a-z0-9.]+)?)\"}, instance)",
+        "definition": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\\\.[a-z0-9.]+)?)\", cluster=\"$cluster\"}, instance)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\\\.[a-z0-9.]+)?)\"}, instance)",
+          "query": "label_values(node_uname_info{nodename=~\"(?i:($node)(\\\\.[a-z0-9.]+)?)\", cluster=\"$cluster\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix 

### :dart: What has been changed and why do we need it?

- The query for the `instance` variable now also filters on `cluster=$cluster`. This is needed when nodenames are not unique across clusters, e.g. if two clusters both have a node named `node01`.

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

- #143 
