### PR TITLE
fix(k8s-system-coredns.json): replace deprecated CoreDNS metrics with coredns_proxy_equivalents

### DIFF
--- a/dashboards/k8s-system-coredns.json
+++ b/dashboards/k8s-system-coredns.json
@@ -841,7 +841,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "sum(rate(coredns_forward_requests_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "$resolution",
           "legendFormat": "total forward requests",
           "refId": "A"
@@ -937,7 +937,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "sum(rate(coredns_forward_responses_total{rcode=~\"SERVFAIL|REFUSED\", cluster=~\"$cluster\"}[$__rate_interval])) by (rcode)",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", rcode=~\"SERVFAIL|REFUSED\", cluster=~\"$cluster\"}[$__rate_interval])) by (rcode)",
           "interval": "$resolution",
           "legendFormat": "{{ rcode }}",
           "refId": "A"


### PR DESCRIPTION
# Pull Request

## Required Fields

### 🔍 What kind of change is it?

- fix

### 🎯 What has been changed and why do we need it?

- Updated PromQL expressions in the `k8s-system-coredns.json` dashboard to replace deprecated CoreDNS metrics (`coredns_forward_requests_total` and `coredns_forward_responses_total`) with their recommended equivalents (`coredns_proxy_request_duration_seconds_count` with the label `proxy_name="forward"`).  
- This fixes issues caused by obsolete metrics and ensures compatibility with recent CoreDNS versions.  
- The change aligns with the project scope and is compatible with kube-prometheus-stack.

### ✅ Which issue(s) this PR fixes?

- Fixes missing data in the "CoreDNS - Total Forward Requests" and "CoreDNS - DNS Errors" graphs.
