### PR TITLE
fix(k8s-views-nodes): aggregate series for ram total and uptime panels

### DIFF
--- a/dashboards/k8s-views-nodes.json
+++ b/dashboards/k8s-views-nodes.json
@@ -812,7 +812,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "machine_memory_bytes{node=\"$node\", cluster=\"$cluster\"}",
+          "expr": "sum(machine_memory_bytes{node=\"$node\", cluster=\"$cluster\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -885,7 +885,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
+          "expr": "sum(node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

The panels do not aggregate series and they break when nodes restart.

Before and after:

<img width="1908" height="646" alt="image" src="https://github.com/user-attachments/assets/1c9f85ae-e15f-4cc1-8261-c0b2fb082a68" />

<img width="1926" height="651" alt="image" src="https://github.com/user-attachments/assets/69c14cc6-c535-480e-9650-09e74c2f44e3" />

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

Fixes: #165

### :speech_balloon: Additional information?

