### PR TITLE
Added two panels for pods scheduling status

### DIFF
--- a/dashboards/k8s-views-pods.json
+++ b/dashboards/k8s-views-pods.json
@@ -2190,7 +2190,7 @@
           ],
           "show": false
         },
-        "showHeader": true,
+        "showHeader": true
       },
       "pluginVersion": "11.3.1",
       "targets": [


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- feat

### :dart: What has been changed and why do we need it?

**Added Kubernetes pod monitoring panels to Grafana dashboard**

**Changes:**
- Added "Unscheduled Pods" panel - tracks pods that cannot be assigned to nodes due to resource constraints or scheduling issues
- Added "Container Issues" panel - monitors containers in CrashLoopBackOff, ErrImagePull, or ImagePullBackOff states

**Why we need it:**
These panels provide visibility into pod and container health issues that were previously not monitored:
- Unscheduled pods indicate infrastructure problems (insufficient CPU/memory, node selector mismatches, resource quotas)
- Container issues surface application-level problems (crashes, image pull failures, misconfigurations)

Early detection of these issues enables faster incident response and reduces downtime.


After:
![Image 10 10 2025 at 08 58](https://github.com/user-attachments/assets/3d5ce3b2-c313-47f0-8a57-bd52839fe6ed)

- Note: Fields in tables are removed in this image.