### PR TITLE
[🤖] feat(k8s-system-api-server): add p99 request latency percentile panels

### DIFF
--- a/dashboards/k8s-system-api-server.json
+++ b/dashboards/k8s-system-api-server.json
@@ -769,7 +769,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -778,6 +778,194 @@
         "w": 12,
         "x": 0,
         "y": 24
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum by (verb, le) (rate(apiserver_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"$job\"}[$__rate_interval])))",
+          "interval": "$resolution",
+          "legendFormat": "p99 {{ verb }}",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server - Request Latency p99 by verb",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum by (resource, le) (rate(apiserver_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"$job\"}[$__rate_interval])))",
+          "interval": "$resolution",
+          "legendFormat": "p99 {{ resource }}",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server - Request Latency p99 by resource",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
       },
       "id": 50,
       "options": {
@@ -871,7 +1059,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 32
       },
       "id": 51,
       "options": {
@@ -965,7 +1153,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 40
       },
       "id": 40,
       "options": {
@@ -1059,7 +1247,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 40
       },
       "id": 56,
       "options": {
@@ -1154,7 +1342,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 48
       },
       "id": 47,
       "options": {
@@ -1248,7 +1436,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 48
       },
       "id": 48,
       "options": {
@@ -1417,6 +1605,6 @@
   "timezone": "",
   "title": "Kubernetes / System / API Server",
   "uid": "k8s_system_apisrv",
-  "version": 21,
+  "version": 22,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

The existing latency panels on the API Server dashboard compute **average** (mean) latency using `sum(rate(duration_sum)) / sum(rate(duration_count))`. While useful for general trends, average latency masks tail latency issues that directly impact user experience and SLO compliance.

This PR adds two new panels using `histogram_quantile(0.99, ...)` to surface **p99 request latency**:

| Panel | Purpose |
|-------|---------|
| **Request Latency p99 by verb** | Identifies which API operations (GET, LIST, WATCH, etc.) have the worst tail latency |
| **Request Latency p99 by resource** | Identifies which resource types (pods, nodes, configmaps, etc.) cause the highest latency |

## Why p99?

- **SLO monitoring**: Kubernetes SLOs are defined in terms of percentile latency (e.g., 99% of non-LIST requests should complete within 1s). Average latency cannot detect SLO violations.
- **Tail latency visibility**: A small number of slow requests can significantly impact user experience but are invisible in mean latency.
- **Standard practice**: The [Kubernetes SIG Scalability dashboard](https://github.com/kubernetes/perf-tests) and kube-prometheus mixins both use histogram_quantile for latency monitoring.

## Changes

- Added 2 new timeseries panels at y=24, placed directly below the existing average latency panels for easy comparison
- Used `histogram_quantile(0.99, sum by (<dimension>, le) (rate(apiserver_request_duration_seconds_bucket{...}[$__rate_interval])))` 
- Unit set to `s` (seconds) to match the native metric unit
- Shifted all subsequent panels down by 8 to accommodate
- Dashboard version bumped from 21 to 22

## Checklist

- [x] Dashboard version bumped
- [x] Conventional commit format used
- [x] AI-assisted contribution clearly identified with 🤖 scope