### PR TITLE
[🤖] feat(k8s-system-coredns): add cache hit rate and forward request latency panels

### DIFF
--- a/dashboards/k8s-system-coredns.json
+++ b/dashboards/k8s-system-coredns.json
@@ -1156,6 +1156,212 @@
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(coredns_cache_hits_total{instance=~\"$instance\", cluster=~\"$cluster\", job=~\"$job\"}[$__rate_interval]))\n/\n(\n  sum(rate(coredns_cache_hits_total{instance=~\"$instance\", cluster=~\"$cluster\", job=~\"$job\"}[$__rate_interval]))\n  +\n  sum(rate(coredns_cache_misses_total{instance=~\"$instance\", cluster=~\"$cluster\", job=~\"$job\"}[$__rate_interval]))\n) * 100",
+          "interval": "",
+          "legendFormat": "Hit Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "CoreDNS - Cache Hit Rate %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(coredns_proxy_request_duration_seconds_bucket{proxy_name=\"forward\", cluster=~\"$cluster\", job=~\"$job\"}[$__rate_interval])))",
+          "interval": "",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(coredns_proxy_request_duration_seconds_bucket{proxy_name=\"forward\", cluster=~\"$cluster\", job=~\"$job\"}[$__rate_interval])))",
+          "interval": "",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "title": "CoreDNS - Forward Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
           "custom": {
             "hideFrom": {
               "legend": false,
@@ -1173,7 +1379,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 51
       },
       "id": 27,
       "options": {
@@ -1192,7 +1398,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-9
+          "le": 1e-09
         },
         "legend": {
           "show": true
@@ -1253,7 +1459,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 51
       },
       "id": 28,
       "options": {
@@ -1272,7 +1478,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-9
+          "le": 1e-09
         },
         "legend": {
           "show": true
@@ -1333,7 +1539,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 53
+        "y": 61
       },
       "id": 29,
       "options": {
@@ -1352,7 +1558,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-9
+          "le": 1e-09
         },
         "legend": {
           "show": true
@@ -1595,6 +1801,6 @@
   "timezone": "",
   "title": "Kubernetes / System / CoreDNS",
   "uid": "k8s_system_coredns",
-  "version": 22,
+  "version": 23,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

Add two new panels to the CoreDNS dashboard that surface **derived metrics** currently not visible, placed directly below the existing cache section.

## New Panels

### 1. CoreDNS - Cache Hit Rate %

Shows the percentage of DNS queries served from cache:

```promql
sum(rate(coredns_cache_hits_total{...}[$__rate_interval]))
/
(
  sum(rate(coredns_cache_hits_total{...}[$__rate_interval]))
  +
  sum(rate(coredns_cache_misses_total{...}[$__rate_interval]))
) * 100
```

**Why**: The existing "Cache Hits / Misses" panel shows raw hit/miss rates, but operators need the **derived ratio** to evaluate cache effectiveness and tune `cache-size` and TTL settings. A drop in cache hit rate is a key signal for DNS performance degradation.

### 2. CoreDNS - Forward Request Latency

Shows p99 and p50 upstream DNS resolution latency:

```promql
histogram_quantile(0.99, sum by (le) (
  rate(coredns_proxy_request_duration_seconds_bucket{proxy_name="forward", ...}[$__rate_interval])
))
```

**Why**: The existing dashboard shows forward request **count** but not **latency**. When CoreDNS forwards queries to upstream resolvers, latency directly impacts DNS resolution time for pods. This panel helps diagnose slow upstream resolvers, network issues, or resolver overload.

## Changes

- Added 2 new timeseries panels at y=43, below the cache hits/misses and cache size panels
- Shifted heatmap panels (DNS request duration, request size, response size) down by 8
- Dashboard version bumped from 22 to 23

## Checklist

- [x] Dashboard version bumped
- [x] Conventional commit format used
- [x] AI-assisted contribution clearly identified with 🤖 scope