### PR TITLE
fix(k8s-views-pods): max memory usage by container accurate over large time ranges

### DIFF
--- a/dashboards/k8s-views-pods.json
+++ b/dashboards/k8s-views-pods.json
@@ -1702,7 +1702,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}) by (container, id)",
+          "expr": "sum(max_over_time(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container, id)",
           "interval": "",
           "legendFormat": "{{ container }}",
           "range": true,

--- a/dashboards/k8s-views-pods.json
+++ b/dashboards/k8s-views-pods.json
@@ -2989,6 +2989,6 @@
   "timezone": "",
   "title": "Kubernetes / Views / Pods",
   "uid": "k8s_views_pods",
-  "version": 39,
+  "version": 40,
   "weekStart": ""
 }


### PR DESCRIPTION
# Pull Request

## Required Fields

### :mag_right: What kind of change is it?

- fix

### :dart: What has been changed and why do we need it?

- The "Max" memory visualization on the k8s-views-pods dashboard should accurately display the absolute peak memory usage achieved by the container within the queried timeframe, regardless of how far the user zooms out.

## Optional Fields

### :heavy_check_mark: Which issue(s) this PR fixes?

- FIxes #181

### :speech_balloon: Additional information?

- Bumped dashboard version
